### PR TITLE
Upper bound on TensorFlow version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ box2d-py>=2.3.8
 gym>=0.10.3
 mujoco-py>=2.0.2.2
 numpy>=1.15.4
-tensorflow>=1.12.0
+tensorflow>=1.12.0,<2.0.0


### PR DESCRIPTION
The current code fails with TensorFlow 2.0, see error message below. For now, this version cap should patch the issue.

```
Traceback (most recent call last):
  File "run.py", line 9, in <module>
    import learning.awr_agent as awr_agent
  File "awr/learning/awr_agent.py", line 6, in <module>
    import util.net_util as net_util
  File "awr/util/net_util.py", line 5, in <module>
    weight_init=tf.contrib.layers.xavier_initializer(),
AttributeError: module 'tensorflow' has no attribute 'contrib'
```
